### PR TITLE
Actually *use* hidden unit locations. :)

### DIFF
--- a/custom.yaml
+++ b/custom.yaml
@@ -1,7 +1,7 @@
  !obj:pylearn2.train.Train {
         "dataset": !pkl: "${PYLEARN2_DATA_PATH}/vanhateren/train.pkl",
         "model": !obj:sparserf_autoencoder.SparseRFAutoencoder {
-            "nhid" : 64,
+            "nhid" : 1024,
             "nvis" : 1024,
             "irange" : 0.05,
             "corruptor": !obj:pylearn2.corruption.BinomialCorruptor {
@@ -10,8 +10,8 @@
             "act_enc": "tanh",
             "act_dec": null,    # Linear activation on the decoder side.
 
-            "numCons" : 16,
-            "sigma" : [[3, 0], [0, 3]],
+            "numCons" : 10,
+            "sigma" : [[2, 0], [0, 2]],
             "imageSize" : [32, 32],
 
         },

--- a/sparserf_autoencoder.py
+++ b/sparserf_autoencoder.py
@@ -45,10 +45,9 @@ class SparseRFAutoencoder(DenoisingAutoencoder):
         hidden units as there are pixels to place.
         Then the code expands the reduced image back out to
         compute the hidden unit locations.
+
+        sets self.hiddenUnitLocs to [nhidden x 2]
         """
-
-        self.hiddenUnitLocs = np.array([np.round(self.imageSize / 2)])
-
         imgHeight = self.imageSize[0]
         imgLength = self.imageSize[1]
         numPixels = imgHeight * imgLength
@@ -83,14 +82,15 @@ class SparseRFAutoencoder(DenoisingAutoencoder):
         # Create the outputs from the grids
         connection_matrix = np.zeros(self.imageSize, dtype=bool)
         connection_matrix[Y, X] = True
-        import matplotlib.pyplot as plt
-        plt.imshow(connection_matrix)
-        plt.title('connection matrix')
-        plt.show()
+        if False:  # debug plotting code
+            import matplotlib.pyplot as plt
+            plt.imshow(connection_matrix)
+            plt.title('connection matrix')
+            plt.show()
         assert np.count_nonzero(connection_matrix) == self.nhid, \
             '# of requested locations must match the # of provided locations!'
 
-        return connection_matrix
+        self.hiddenUnitLocs = np.asarray(np.nonzero(connection_matrix)).T
 
     def _create_connection_mask(self):
         # Define some useful local variables for sake of clarity


### PR DESCRIPTION
Fix bug; actually *use* the hidden unit locations computed.
Now, here's the weight matrix:
![image](https://cloud.githubusercontent.com/assets/4072455/6068840/34e4ecfa-ad34-11e4-917e-d94fa8679b8e.png)
